### PR TITLE
Use await in function example

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ import 'package:image_test_utils/image_test_utils.dart';
 
 void main() {
   testWidgets('should not crash', (WidgetTester tester) async {
-    provideMockedNetworkImages(() async {
+    await provideMockedNetworkImages(() async {
       /// Now we can pump NetworkImages without crashing our tests. Yay!
       await tester.pumpWidget(
         MaterialApp(


### PR DESCRIPTION
Without `await`, the error below occurs:

```
Asynchronous call to guarded function leaked. You must use "await" with all Future-returning test
APIs.
```