### PR TITLE
Use content length of provided image bytes

### DIFF
--- a/lib/image_test_utils.dart
+++ b/lib/image_test_utils.dart
@@ -64,7 +64,7 @@ MockHttpClient _createMockImageHttpClient(SecurityContext _, List<int> imageByte
   when(client.getUrl(any)).thenAnswer((_) => Future<HttpClientRequest>.value(request));
   when(request.headers).thenReturn(headers);
   when(request.close()).thenAnswer((_) => Future<HttpClientResponse>.value(response));
-  when(response.contentLength).thenReturn(_transparentImage.length);
+  when(response.contentLength).thenReturn(imageBytes.length);
   when(response.statusCode).thenReturn(HttpStatus.ok);
   when(response.listen(any)).thenAnswer((Invocation invocation) {
     final void Function(List<int>) onData = invocation.positionalArguments[0];


### PR DESCRIPTION
I noticed the content length returned is always the length of the transparent image.
