### PR TITLE
Fixed custom imageBytes

### DIFF
--- a/lib/image_test_utils.dart
+++ b/lib/image_test_utils.dart
@@ -64,13 +64,14 @@ MockHttpClient _createMockImageHttpClient(SecurityContext _, List<int> imageByte
   when(client.getUrl(any)).thenAnswer((_) => Future<HttpClientRequest>.value(request));
   when(request.headers).thenReturn(headers);
   when(request.close()).thenAnswer((_) => Future<HttpClientResponse>.value(response));
-  when(response.contentLength).thenReturn(_transparentImage.length);
+  when(response.contentLength).thenReturn(imageBytes.length);
   when(response.statusCode).thenReturn(HttpStatus.ok);
-  when(response.listen(any)).thenAnswer((Invocation invocation) {
-    final void Function(List<int>) onData = invocation.positionalArguments[0];
-    final void Function() onDone = invocation.namedArguments[#onDone];
-    final void Function(Object, [StackTrace]) onError = invocation.namedArguments[#onError];
-    final bool cancelOnError = invocation.namedArguments[#cancelOnError];
+
+  when(response.listen(any, onError: anyNamed('onError'), onDone: anyNamed('onDone'), cancelOnError: anyNamed('cancelOnError'))).thenAnswer((Invocation invocation) {
+    final void Function(List<int>) onData = invocation.positionalArguments[0] as void Function(List<int>);
+    final void Function() onDone = invocation.namedArguments[#onDone] as void Function();
+    final void Function(Object, [StackTrace]) onError = invocation.namedArguments[#onError] as void Function(Object, [StackTrace]);
+    final bool cancelOnError = invocation.namedArguments[#cancelOnError] as bool;
 
     return Stream<List<int>>.fromIterable(<List<int>>[imageBytes])
         .listen(onData, onDone: onDone, onError: onError, cancelOnError: cancelOnError);


### PR DESCRIPTION
The mocked response.listen never gets called because the named parameters aren't matched.
The mocked contentLength always returned the transparent image length.
#4 